### PR TITLE
Update button styles

### DIFF
--- a/src/demos/colorpicker/colorpicker-demo.component.html
+++ b/src/demos/colorpicker/colorpicker-demo.component.html
@@ -30,7 +30,7 @@
 <p>
   <button
     type="button"
-    class="sky-btn sky-btn-default sky-margin-inline-default"
+    class="sky-btn sky-btn-primary sky-margin-inline-default"
     (click)="openColorpicker()"
   >
     Open colorpicker

--- a/src/demos/toast/toast-demo.component.html
+++ b/src/demos/toast/toast-demo.component.html
@@ -27,7 +27,7 @@
   </button>
 
   <button
-    class="sky-btn sky-btn-primary sky-margin-inline-default"
+    class="sky-btn sky-btn-default sky-margin-inline-default"
     type="button"
     (click)="openComponent()"
   >


### PR DESCRIPTION
Remove primary styling for one of the toast demo buttons so that there is only one primary action. And add primary styling for one of the colorpicker buttons in the third section of the colorpicker demo for consistency so that each one has a primary action.